### PR TITLE
remove duplicate token lifetime value from the app controller

### DIFF
--- a/ResetPasswordBundle/src/ResetPasswordHelper.php
+++ b/ResetPasswordBundle/src/ResetPasswordHelper.php
@@ -129,6 +129,14 @@ class ResetPasswordHelper implements ResetPasswordHelperInterface
         $this->repository->removeResetPasswordRequest($request);
     }
 
+    /**
+     * @inheritDoc
+     */
+    public function getTokenLifetime(): int
+    {
+        return $this->resetRequestLifetime;
+    }
+
     private function findToken(string $token): ResetPasswordRequestInterface
     {
         $selector = substr($token, 0, self::SELECTOR_LENGTH);

--- a/ResetPasswordBundle/src/ResetPasswordHelperInterface.php
+++ b/ResetPasswordBundle/src/ResetPasswordHelperInterface.php
@@ -15,4 +15,11 @@ interface ResetPasswordHelperInterface
     public function validateTokenAndFetchUser(string $fullToken): object;
 
     public function removeResetRequest(string $fullToken): void;
+
+    /**
+     * Get the length of time in seconds a token is valid
+     *
+     * Format with ResetPasswordTimeHelper::getFormattedSeconds()
+     */
+    public function getTokenLifetime(): int;
 }

--- a/ResetPasswordBundle/src/ResetPasswordTimeHelper.php
+++ b/ResetPasswordBundle/src/ResetPasswordTimeHelper.php
@@ -5,8 +5,9 @@ namespace SymfonyCasts\Bundle\ResetPassword;
 class ResetPasswordTimeHelper
 {
     /**
-     * @TODO WIP
-     * turn 3600 seconds into something human friendly for templates...
+     * Convert seconds into a human readable string
+     *
+     * Providing 8100 will return 2 hours 15 minutes
      */
     public static function getFormattedSeconds(int $seconds): string
     {
@@ -25,13 +26,18 @@ class ResetPasswordTimeHelper
         }
 
         if ($minutes > 0) {
-            if (!empty($time)) {
-                $time .= ' ';
-            }
-
-            $time .= "$minutes minutes";
+            $time = (self::addSpace($time)) . "$minutes minutes";
         }
 
         return $time;
+    }
+
+    private static function addSpace(string $time): string
+    {
+        if (empty($time)) {
+            return '';
+        }
+
+        return $time . ' ';
     }
 }

--- a/ResetPasswordBundle/src/ResetPasswordTimeHelper.php
+++ b/ResetPasswordBundle/src/ResetPasswordTimeHelper.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SymfonyCasts\Bundle\ResetPassword;
+
+class ResetPasswordTimeHelper
+{
+    /**
+     * @TODO WIP
+     * turn 3600 seconds into something human friendly for templates...
+     */
+    public static function getFormattedSeconds(int $seconds): string
+    {
+
+        $hours = (int) floor($seconds / 3600);
+        $minutes = (int) floor(($seconds / 60) % 60);
+
+        $time = '';
+
+        if ($hours === 1) {
+            $time .= "$hours hour";
+        }
+
+        if ($hours >= 2) {
+            $time .= "$hours hours";
+        }
+
+        if ($minutes > 0) {
+            if (!empty($time)) {
+                $time .= ' ';
+            }
+
+            $time .= "$minutes minutes";
+        }
+
+        return $time;
+    }
+}

--- a/ResetPasswordBundle/src/tests/UnitTests/ResetPasswordTimeHelperTest.php
+++ b/ResetPasswordBundle/src/tests/UnitTests/ResetPasswordTimeHelperTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SymfonyCasts\Bundle\ResetPassword\tests\UnitTests;
+
+use SymfonyCasts\Bundle\ResetPassword\ResetPasswordTimeHelper;
+use PHPUnit\Framework\TestCase;
+
+/** @TODO WIP */
+class ResetPasswordTimeHelperTest extends TestCase
+{
+    public function secondsDataProvider(): \Generator
+    {
+        yield [3600, '1 hour'];
+        yield [7200, '2 hours'];
+        yield [900, '15 minutes'];
+        yield [4500, '1 hour 15 minutes'];
+        yield [8100, '2 hours 15 minutes'];
+    }
+
+    /**
+     * @dataProvider secondsDataProvider
+     */
+    public function testReturnsWhatIWant(int $seconds, string $expected): void
+    {
+        self::assertSame($expected, ResetPasswordTimeHelper::getFormattedSeconds($seconds));
+    }
+}

--- a/src/Controller/ForgotPasswordController.php
+++ b/src/Controller/ForgotPasswordController.php
@@ -20,6 +20,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 use SymfonyCasts\Bundle\ResetPassword\Exception\ResetPasswordExceptionInterface;
 use SymfonyCasts\Bundle\ResetPassword\Model\ResetPasswordToken;
 use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
+use SymfonyCasts\Bundle\ResetPassword\ResetPasswordTimeHelper;
 
 /**
  * @Route("/forgot-password")
@@ -29,8 +30,15 @@ class ForgotPasswordController extends AbstractController
     private const SESSION_TOKEN_KEY = 'forgot_password_token';
     private const SESSION_CAN_CHECK_EMAIL = 'forgot_password_check_email';
 
-    /** @TODO this value should be generated/retrieved from the config... */
-    private const LIFETIME_HOURS = 1;
+    /**
+     * @var ResetPasswordHelperInterface
+     */
+    private $resetPasswordHelper;
+
+    public function __construct(ResetPasswordHelperInterface $resetPasswordHelper)
+    {
+        $this->resetPasswordHelper = $resetPasswordHelper;
+    }
 
     /**
      * @Route("/request", name="app_forgot_password_request")
@@ -107,7 +115,7 @@ class ForgotPasswordController extends AbstractController
         $session->remove(self::SESSION_CAN_CHECK_EMAIL);
 
         return $this->render('forgot_password/check_email.html.twig', [
-            'tokenLifetime' => self::LIFETIME_HOURS,
+            'tokenLifetime' => ResetPasswordTimeHelper::getFormattedSeconds($this->resetPasswordHelper->getTokenLifetime()),
         ]);
     }
 

--- a/templates/forgot_password/check_email.html.twig
+++ b/templates/forgot_password/check_email.html.twig
@@ -3,6 +3,6 @@
 {% block title %}Check your e-mail address{% endblock %}
 
 {% block body %}
-    <p>An email has been sent. It contains a link you must click to reset your password. This link will expire in {{ tokenLifetime }} hours.</p>
+    <p>An email has been sent. It contains a link you must click to reset your password. This link will expire in {{ tokenLifetime }}.</p>
 <p>If you don't get an email please check your spam folder or <a href="{{ path('app_forgot_password_request') }}">try again</a>.</p>
 {% endblock %}


### PR DESCRIPTION
The helper has the token lifetime value as a property for use in generating/validating tokens. 

Early on we defined a lifetime value in the controller for use in twig templates. (your link expires in x time.) This PR removes the app lifetime constant and uses newly created methods from the bundle to get that value.

- Added `getTokenLifetime()` in helper
- Created `ResetPasswordTimeHelper::class` - format time (seconds) into something readable by humans

Naming conventions could probably use some love.. New PR will be introduced in the bundle for after the kinks are worked out here.. 