### PR TITLE
use master to utilize new security helper methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "dama/doctrine-test-bundle": "^6.3",
         "doctrine/doctrine-fixtures-bundle": "^3.3",
-        "symfony/maker-bundle": "^1.14",
+        "symfony/maker-bundle": "@dev",
         "symfony/phpunit-bridge": "^5.0",
         "symfony/test-pack": "^1.0",
         "vimeo/psalm": "^3.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea39ace8be0f3729ed617b98e18c57b6",
+    "content-hash": "c92ca8cb632bb892c81e6c3a500e57f3",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -5730,16 +5730,16 @@
         },
         {
             "name": "symfony/maker-bundle",
-            "version": "v1.14.3",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/maker-bundle.git",
-                "reference": "c864e7f9b8d1e1f5f60acc3beda11299f637aded"
+                "reference": "674aa82cd4259166cca2e59ed61e3e6c9de23202"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/maker-bundle/zipball/c864e7f9b8d1e1f5f60acc3beda11299f637aded",
-                "reference": "c864e7f9b8d1e1f5f60acc3beda11299f637aded",
+                "url": "https://api.github.com/repos/symfony/maker-bundle/zipball/674aa82cd4259166cca2e59ed61e3e6c9de23202",
+                "reference": "674aa82cd4259166cca2e59ed61e3e6c9de23202",
                 "shasum": ""
             },
             "require": {
@@ -5794,7 +5794,7 @@
                 "scaffold",
                 "scaffolding"
             ],
-            "time": "2019-11-07T00:56:03+00:00"
+            "time": "2020-01-31T19:42:39+00:00"
         },
         {
             "name": "symfony/phpunit-bridge",
@@ -6128,7 +6128,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "symfony/maker-bundle": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
Need access to `InteractiveSecurityHelper::guessEmailField()` and the like for make:reset-password dev..